### PR TITLE
docs: add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,44 @@
+name: 🔀 Pull Request Template
+description: Guidelines for submitting a PR to FireRed-OpenStoryline
+
+---
+
+## Description
+
+Brief summary of the change and what it accomplishes.
+
+Fixes #(issue number)
+
+## Type of Change
+
+- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
+- [ ] ✨ New feature (non-breaking change which adds functionality)
+- [ ] 🧪 Test (adds or updates tests)
+- [ ] 📝 Documentation (adds or updates documentation)
+- [ ] 🔧 Chore (infrastructure, config, CI, formatting)
+- [ ] ⚡ Performance (improves speed or reduces memory)
+
+## Changes
+
+List the key changes made in this PR:
+
+- 
+- 
+- 
+
+## Checklist
+
+- [ ] Code follows the project's coding style (ruff format/lint passes)
+- [ ] Self-reviewed the code
+- [ ] Added/updated tests if applicable
+- [ ] Updated documentation if applicable
+- [ ] `python3 -m py_compile` passes for all changed `.py` files
+- [ ] Does not modify `config.toml` (contains local API keys)
+
+## Testing
+
+How to test this change manually:
+
+```bash
+# Add reproduction steps
+```


### PR DESCRIPTION
## Summary
- add a default pull request template under `.github/PULL_REQUEST_TEMPLATE.md`
- include change-type checkboxes and a repository-specific validation checklist
- remind contributors not to modify `config.toml`

## Validation
- template content reviewed locally

Closes #65
