### PR TITLE
ci: use Python 3.11 in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install CI dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Install CI dependencies
         run: |
-          pip install ruff pylint pytest numpy pydantic
+          pip install ruff pylint pytest numpy pydantic mcp
 
       - name: Lint targeted Python files with Ruff
         run: |


### PR DESCRIPTION
## Summary
- switch the CI workflow from Python 3.10 to Python 3.11
- align GitHub Actions with the repository's documented Python 3.11+ requirement
- install the `mcp` package required by the smoke-test import chain

## Evidence
- the latest failed `main` workflow run (`CI`, run `24217732522`) failed in `Lint targeted Python files with Pylint`
- the same failing Pylint step recurred across recent `main` runs (`24217732522`, `24217665099`, `24214631621`)
- `scripts/update_config.py` imports `tomllib`, which is unavailable on Python 3.10
- repo docs already require Python 3.11+ (`README.md`, `README_zh.md`, `docs/developer-setup.md`)
- after switching CI to Python 3.11, PR run `24220072971` advanced past Pylint and then failed in `Pytest smoke tests` because `tests/test_node_schema.py` imports `open_storyline.nodes.node_state`, whose import chain reaches `mcp.server.fastmcp`, but the workflow only installed `ruff pylint pytest numpy pydantic`
- `requirements.txt` already declares `mcp==1.26.0`, so adding `mcp` to the CI install step aligns CI with project dependencies

## Validation
- `uv run --python 3.10 --no-project python -c "import tomllib"` → `ModuleNotFoundError: No module named 'tomllib'`
- `uv run --python 3.11 --with pylint --with ruff --with pytest --with numpy --with pydantic --with mcp --no-project ruff check --output-format=github scripts/update_config.py tests/test_remotion_integration.py`
- `uv run --python 3.11 --with pylint --with ruff --with pytest --with numpy --with pydantic --with mcp --no-project ruff format --check scripts/update_config.py tests/test_remotion_integration.py`
- `uv run --python 3.11 --with pylint --with ruff --with pytest --with numpy --with pydantic --with mcp --no-project env PYTHONPATH=src pylint --errors-only scripts/update_config.py tests/test_remotion_integration.py`
- `uv run --python 3.11 --with pylint --with ruff --with pytest --with numpy --with pydantic --with mcp --no-project python -m py_compile scripts/update_config.py tests/test_remotion_integration.py`
- `uv run --python 3.11 --with pylint --with ruff --with pytest --with numpy --with pydantic --with mcp --no-project pytest tests/test_ffmpeg_utils.py tests/test_node_manager.py tests/test_node_schema.py -q`
